### PR TITLE
Automatically Download and Install Updates

### DIFF
--- a/ExtensionUpdater/ExtensionUpdater.csproj
+++ b/ExtensionUpdater/ExtensionUpdater.csproj
@@ -1,79 +1,80 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AC48FFD8-57E6-47FF-B728-270E3F0B1F37}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ExtensionUpdater</RootNamespace>
-    <AssemblyName>ExtensionUpdater</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="DTO.cs" />
-    <Compile Include="ExtensionUpdaterPlugin.cs" />
-    <Compile Include="GitHub.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="YamlUtils.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="extension.yaml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Extensions.Common\Extensions.Common.csproj">
-      <Project>{5ac34e06-706a-4706-84d4-510aa345d7fc}</Project>
-      <Name>Extensions.Common</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>10.0.1</Version>
-    </PackageReference>
-    <PackageReference Include="PlayniteSDK">
-      <Version>5.5.0</Version>
-    </PackageReference>
-    <PackageReference Include="YamlDotNet">
-      <Version>5.4.0</Version>
-    </PackageReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{AC48FFD8-57E6-47FF-B728-270E3F0B1F37}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>ExtensionUpdater</RootNamespace>
+        <AssemblyName>ExtensionUpdater</AssemblyName>
+        <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="PresentationFramework" />
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="DTO.cs" />
+        <Compile Include="ExtensionUpdaterPlugin.cs" />
+        <Compile Include="GitHub.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="YamlUtils.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="extension.yaml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Extensions.Common\Extensions.Common.csproj">
+        <Project>{5ac34e06-706a-4706-84d4-510aa345d7fc}</Project>
+        <Name>Extensions.Common</Name>
+      </ProjectReference>
+    </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Newtonsoft.Json">
+        <Version>10.0.1</Version>
+      </PackageReference>
+      <PackageReference Include="PlayniteSDK">
+        <Version>5.5.0</Version>
+      </PackageReference>
+      <PackageReference Include="YamlDotNet">
+        <Version>8.1.2</Version>
+      </PackageReference>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>
     <Target Name="AfterBuild">
     </Target>
     -->
+
 </Project>

--- a/ExtensionUpdater/ExtensionUpdater.csproj
+++ b/ExtensionUpdater/ExtensionUpdater.csproj
@@ -1,80 +1,79 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{AC48FFD8-57E6-47FF-B728-270E3F0B1F37}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>ExtensionUpdater</RootNamespace>
-        <AssemblyName>ExtensionUpdater</AssemblyName>
-        <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="PresentationFramework" />
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="DTO.cs" />
-        <Compile Include="ExtensionUpdaterPlugin.cs" />
-        <Compile Include="GitHub.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="YamlUtils.cs" />
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="extension.yaml">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\Extensions.Common\Extensions.Common.csproj">
-        <Project>{5ac34e06-706a-4706-84d4-510aa345d7fc}</Project>
-        <Name>Extensions.Common</Name>
-      </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json">
-        <Version>10.0.1</Version>
-      </PackageReference>
-      <PackageReference Include="PlayniteSDK">
-        <Version>5.5.0</Version>
-      </PackageReference>
-      <PackageReference Include="YamlDotNet">
-        <Version>8.1.2</Version>
-      </PackageReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AC48FFD8-57E6-47FF-B728-270E3F0B1F37}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ExtensionUpdater</RootNamespace>
+    <AssemblyName>ExtensionUpdater</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DTO.cs" />
+    <Compile Include="ExtensionUpdaterPlugin.cs" />
+    <Compile Include="GitHub.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="YamlUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="extension.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Extensions.Common\Extensions.Common.csproj">
+      <Project>{5ac34e06-706a-4706-84d4-510aa345d7fc}</Project>
+      <Name>Extensions.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>10.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="PlayniteSDK">
+      <Version>5.5.0</Version>
+    </PackageReference>
+    <PackageReference Include="YamlDotNet">
+      <Version>5.4.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>
     <Target Name="AfterBuild">
     </Target>
     -->
-
 </Project>

--- a/ExtensionUpdater/ExtensionUpdaterPlugin.cs
+++ b/ExtensionUpdater/ExtensionUpdaterPlugin.cs
@@ -74,7 +74,6 @@ namespace ExtensionUpdater
         {
             Task.Run(() =>
             {
-                // Clear temporary dowload folder and re-create it
                 var downloadPath = Path.Combine(GetPluginUserDataPath(), "Temp");
                 if (Directory.Exists(downloadPath))
                     Directory.Delete(downloadPath, true);
@@ -196,13 +195,11 @@ namespace ExtensionUpdater
                             () =>
                             {
                                 Process.Start(latest.html_url);
-                                // Check if there are assets associated with the release
                                 if (latest.assets != null)
                                 {
                                     var playnitePath = Environment.ExpandEnvironmentVariables(PlayniteApi.Paths.ApplicationPath);
                                     playnitePath = Path.Combine(playnitePath, "Playnite.DesktopApp.exe");
                                     var options = new List<GenericItemOption>();
-                                    // Add all .pext and .pthm files as options
                                     foreach (var asset in latest.assets)
                                     {
                                         var path = Path.Combine(GetPluginUserDataPath(), "Temp", asset.name);
@@ -212,12 +209,9 @@ namespace ExtensionUpdater
                                             options.Add(new GenericItemOption(asset.name, asset.browser_download_url));
                                         }
                                     }
-                                    // Only try to dowload and install if any options were found
                                     if (options.Count > 0)
                                     {
                                         GenericItemOption selected = options[0];
-                                        // Let the user select a file to download 
-                                        // if multiple extension files have been found
                                         if (options.Count > 1)
                                         {
                                             selected = PlayniteApi.Dialogs.ChooseItemWithSearch(
@@ -227,7 +221,6 @@ namespace ExtensionUpdater
                                                 "Multiple extension files found. Select the one you want to install."
                                             );
                                         }
-                                        // Download and install selected option
                                         if (selected != null)
                                         {
                                             var path = Path.Combine(GetPluginUserDataPath(), "Temp", selected.Name);
@@ -235,12 +228,9 @@ namespace ExtensionUpdater
                                             {
                                                 using (var webclient = new System.Net.WebClient())
                                                 {
-                                                    // Dowload extension file into temporary folder
                                                     webclient.DownloadFile(selected.Description, path);
                                                 }
                                             }, new GlobalProgressOptions($"Dowloading {selected.Name}", false));
-                                            // Open Playnite with installext argument to trigger 
-                                            // extension installation
                                             Process.Start(playnitePath, $"--installext {path}");
                                         }
                                     }

--- a/ExtensionUpdater/ExtensionUpdaterPlugin.cs
+++ b/ExtensionUpdater/ExtensionUpdaterPlugin.cs
@@ -74,6 +74,7 @@ namespace ExtensionUpdater
         {
             Task.Run(() =>
             {
+                // Clear temporary dowload folder and re-create it
                 var downloadPath = Path.Combine(GetPluginUserDataPath(), "Temp");
                 if (Directory.Exists(downloadPath))
                     Directory.Delete(downloadPath, true);
@@ -195,11 +196,13 @@ namespace ExtensionUpdater
                             () =>
                             {
                                 Process.Start(latest.html_url);
+                                // Check if there are assets associated with the release
                                 if (latest.assets != null)
                                 {
                                     var playnitePath = Environment.ExpandEnvironmentVariables(PlayniteApi.Paths.ApplicationPath);
                                     playnitePath = Path.Combine(playnitePath, "Playnite.DesktopApp.exe");
                                     var options = new List<GenericItemOption>();
+                                    // Add all .pext and .pthm files as options
                                     foreach (var asset in latest.assets)
                                     {
                                         var path = Path.Combine(GetPluginUserDataPath(), "Temp", asset.name);
@@ -209,9 +212,12 @@ namespace ExtensionUpdater
                                             options.Add(new GenericItemOption(asset.name, asset.browser_download_url));
                                         }
                                     }
+                                    // Only try to dowload and install if any options were found
                                     if (options.Count > 0)
                                     {
                                         GenericItemOption selected = options[0];
+                                        // Let the user select a file to download 
+                                        // if multiple extension files have been found
                                         if (options.Count > 1)
                                         {
                                             selected = PlayniteApi.Dialogs.ChooseItemWithSearch(
@@ -221,6 +227,7 @@ namespace ExtensionUpdater
                                                 "Multiple extension files found. Select the one you want to install."
                                             );
                                         }
+                                        // Download and install selected option
                                         if (selected != null)
                                         {
                                             var path = Path.Combine(GetPluginUserDataPath(), "Temp", selected.Name);
@@ -228,9 +235,12 @@ namespace ExtensionUpdater
                                             {
                                                 using (var webclient = new System.Net.WebClient())
                                                 {
+                                                    // Dowload extension file into temporary folder
                                                     webclient.DownloadFile(selected.Description, path);
                                                 }
                                             }, new GlobalProgressOptions($"Dowloading {selected.Name}", false));
+                                            // Open Playnite with installext argument to trigger 
+                                            // extension installation
                                             Process.Start(playnitePath, $"--installext {path}");
                                         }
                                     }

--- a/ExtensionUpdater/ExtensionUpdaterPlugin.cs
+++ b/ExtensionUpdater/ExtensionUpdaterPlugin.cs
@@ -76,9 +76,15 @@ namespace ExtensionUpdater
             {
                 // Clear temporary dowload folder and re-create it
                 var downloadPath = Path.Combine(GetPluginUserDataPath(), "Temp");
-                if (Directory.Exists(downloadPath))
-                    Directory.Delete(downloadPath, true);
-                Directory.CreateDirectory(downloadPath);
+                if (Directory.Exists(downloadPath)) {
+                    foreach(var file in Directory.EnumerateFiles(downloadPath, "*.pext")) {
+                        File.Delete(file);
+                    }foreach(var file in Directory.EnumerateFiles(downloadPath, "*.pthm")) {
+                        File.Delete(file);
+                    }
+                } else {
+                    Directory.CreateDirectory(downloadPath);
+                }
                 if (_extensionsDirectories.Count == 0)
                     return;
 

--- a/ExtensionUpdater/ExtensionUpdaterPlugin.cs
+++ b/ExtensionUpdater/ExtensionUpdaterPlugin.cs
@@ -79,7 +79,8 @@ namespace ExtensionUpdater
                 if (Directory.Exists(downloadPath)) {
                     foreach(var file in Directory.EnumerateFiles(downloadPath, "*.pext")) {
                         File.Delete(file);
-                    }foreach(var file in Directory.EnumerateFiles(downloadPath, "*.pthm")) {
+                    }
+                    foreach(var file in Directory.EnumerateFiles(downloadPath, "*.pthm")) {
                         File.Delete(file);
                     }
                 } else {


### PR DESCRIPTION
When clicking the update notification, check whether the github release page contains extension files as assets and give the user the option to download and install one if them automatically. If  more than one extension file exists, let the user choose which one to install.