### PR TITLE
Fanza supports crawling enterprise games

### DIFF
--- a/src/DLSiteMetadata/DLSiteMetadataPlugin.cs
+++ b/src/DLSiteMetadata/DLSiteMetadataPlugin.cs
@@ -33,7 +33,9 @@ public class DLSiteMetadataPlugin : MetadataPlugin
         MetadataField.BackgroundImage,
         MetadataField.CoverImage,
         MetadataField.ReleaseDate,
-        MetadataField.Series
+        MetadataField.Series,
+        MetadataField.Description,
+        MetadataField.Region
     };
 
     public DLSiteMetadataPlugin(IPlayniteAPI playniteAPI) : base(playniteAPI)

--- a/src/DLSiteMetadata/DLSiteMetadataProvider.cs
+++ b/src/DLSiteMetadata/DLSiteMetadataProvider.cs
@@ -40,13 +40,15 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
         {
             if (game.Name.StartsWith(Scrapper.SiteBaseUrl)) return game.Name;
 
-            if (game.Name.StartsWith("RJ", StringComparison.OrdinalIgnoreCase) || game.Name.StartsWith("RE", StringComparison.OrdinalIgnoreCase))
+            if (game.Name.StartsWith("RJ", StringComparison.OrdinalIgnoreCase) ||
+                game.Name.StartsWith("RE", StringComparison.OrdinalIgnoreCase))
             {
                 return $"https://www.dlsite.com/maniax/work/=/product_id/{game.Name}.html";
             }
         }
 
-        var dlSiteLink = game.Links?.FirstOrDefault(link => link.Name.Equals("DLsite", StringComparison.OrdinalIgnoreCase));
+        var dlSiteLink =
+            game.Links?.FirstOrDefault(link => link.Name.Equals("DLsite", StringComparison.OrdinalIgnoreCase));
         return dlSiteLink?.Url;
     }
 
@@ -63,7 +65,8 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
             {
                 // background download so we just choose the first item
 
-                var searchTask = scrapper.ScrapSearchPage(Game.Name, args.CancelToken, _settings.MaxSearchResults, _settings.PreferredLanguage ?? Scrapper.DefaultLanguage);
+                var searchTask = scrapper.ScrapSearchPage(Game.Name, args.CancelToken, _settings.MaxSearchResults,
+                    _settings.PreferredLanguage ?? Scrapper.DefaultLanguage);
                 searchTask.Wait(args.CancelToken);
 
                 var searchResult = searchTask.Result;
@@ -82,7 +85,8 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
                     new List<GenericItemOption>(),
                     searchString =>
                     {
-                        var searchTask = scrapper.ScrapSearchPage(searchString, args.CancelToken, _settings.MaxSearchResults, _settings.PreferredLanguage ?? Scrapper.DefaultLanguage);
+                        var searchTask = scrapper.ScrapSearchPage(searchString, args.CancelToken,
+                            _settings.MaxSearchResults, _settings.PreferredLanguage ?? Scrapper.DefaultLanguage);
                         searchTask.Wait(args.CancelToken);
 
                         var searchResult = searchTask.Result;
@@ -161,7 +165,9 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
         }
 
         var developers = staff
-            .Select(name => (name, _playniteAPI.Database.Companies.Where(x => x.Name is not null).FirstOrDefault(company => company.Name.Equals(name, StringComparison.OrdinalIgnoreCase))))
+            .Select(name => (name,
+                _playniteAPI.Database.Companies.Where(x => x.Name is not null).FirstOrDefault(company =>
+                    company.Name.Equals(name, StringComparison.OrdinalIgnoreCase))))
             .Select(tuple =>
             {
                 var (name, company) = tuple;
@@ -191,7 +197,8 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
             return new MetadataFile(images.First());
         }
 
-        var imageFileOption = _playniteAPI.Dialogs.ChooseImageFile(images.Select(image => new ImageFileOption(image)).ToList(), caption);
+        var imageFileOption =
+            _playniteAPI.Dialogs.ChooseImageFile(images.Select(image => new ImageFileOption(image)).ToList(), caption);
         return imageFileOption == null ? null : new MetadataFile(imageFileOption.Path);
     }
 
@@ -287,5 +294,10 @@ public class DLSiteMetadataProvider : OnDemandMetadataProvider
     {
         var result = GetResult(args);
         return result?.Score;
+    }
+
+    public override IEnumerable<MetadataProperty> GetRegions(GetMetadataFieldArgs args)
+    {
+        return new[] { new MetadataNameProperty("Japan") };
     }
 }

--- a/src/FanzaMetadata.Test/FanzaTests.cs
+++ b/src/FanzaMetadata.Test/FanzaTests.cs
@@ -32,6 +32,8 @@ public class FanzaTests
         Assert.NotNull(res?.GameGenre);
         Assert.NotNull(res?.PreviewImages);
         Assert.NotEmpty(res?.PreviewImages!);
+        Assert.True(res?.Adult);
+        Assert.NotNull(res?.Description);
     }
 
     [Fact]
@@ -94,6 +96,8 @@ public class FanzaTests
         Assert.NotNull(res);
         Assert.NotNull(res?.Title);
         Assert.NotNull(res?.Genres);
+        Assert.NotNull(res?.Description);
+        Assert.True(res?.Adult);
     }
 
 

--- a/src/FanzaMetadata.Test/FanzaTests.cs
+++ b/src/FanzaMetadata.Test/FanzaTests.cs
@@ -70,7 +70,7 @@ public class FanzaTests
     public async void ShouldGetSearchResult()
     {
         var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
-        var res = await scrapper.ScrapSearchPage("家の彼女");
+        var res = await scrapper.ScrapSearchPage("恥辱の制服2");
         Assert.NotEmpty(res);
     }
 
@@ -80,6 +80,17 @@ public class FanzaTests
         var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
         var res = await scrapper.ScrapGamePage(new SearchResult("美少女万華鏡 呪われし伝説の少女", "views_0669",
             "https://dlsoft.dmm.co.jp/detail/views_0669/"));
+        Assert.NotNull(res);
+        Assert.NotNull(res?.Title);
+        Assert.NotNull(res?.Genres);
+    }
+
+    [Fact]
+    public async void ShouldGetScrapperResultFromUrl()
+    {
+        var scrapper =  new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapGamePage("https://dlsoft.dmm.co.jp/detail/moonstn_0014/?i3_ref=search&i3_ord=2",
+            CancellationToken.None);
         Assert.NotNull(res);
         Assert.NotNull(res?.Title);
         Assert.NotNull(res?.Genres);

--- a/src/FanzaMetadata.Test/FanzaTests.cs
+++ b/src/FanzaMetadata.Test/FanzaTests.cs
@@ -1,9 +1,7 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Moq;
-using Moq.Contrib.HttpClient;
-using Playnite.SDK.Models;
 using TestUtils;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,52 +18,112 @@ public class FanzaTests
     }
 
     [Theory]
-    [InlineData("216826")]
-    public async Task TestScrapGamePage(string id)
+    [InlineData("216826", "https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_216826/?i3_ref=search&i3_ord=1")]
+    public async Task TestScrapGamePage(string id, string url)
     {
-        var file = Path.Combine("files", $"{id}.html");
-        Assert.True(File.Exists(file));
+        var scrapper = new DoujinGameScrapper(new XunitLogger<DoujinGameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapGamePage(new SearchResult("爆乳忍法チチシノビ", id, url));
 
-        var handler = new Mock<HttpMessageHandler>();
-        handler
-            .SetupAnyRequest()
-            .ReturnsResponse(File.ReadAllBytes(file));
-
-        var scrapper = new Scrapper(new XunitLogger<Scrapper>(_testOutputHelper), handler.Object);
-        var res = await scrapper.ScrapGamePage(id);
-
-        Assert.NotNull(res.Link);
-        Assert.NotNull(res.Title);
-        Assert.NotNull(res.Circle);
-        Assert.NotNull(res.Genres);
-        Assert.NotEmpty(res.Genres!);
-        Assert.NotNull(res.GameGenre);
-        Assert.NotNull(res.PreviewImages);
-        Assert.NotEmpty(res.PreviewImages!);
+        Assert.NotNull(res?.Link);
+        Assert.NotNull(res?.Title);
+        Assert.NotNull(res?.Circle);
+        Assert.NotNull(res?.Genres);
+        Assert.NotEmpty(res?.Genres!);
+        Assert.NotNull(res?.GameGenre);
+        Assert.NotNull(res?.PreviewImages);
+        Assert.NotEmpty(res?.PreviewImages!);
     }
 
     [Fact]
-    public async Task TestScrapSearchPage()
+    public async Task ShouldGetScrapSearchPage()
     {
-        var file = Path.Combine("files", "search.html");
-        Assert.True(File.Exists(file));
-
-        var handler = new Mock<HttpMessageHandler>();
-        handler
-            .SetupAnyRequest()
-            .ReturnsResponse(File.ReadAllBytes(file));
-
-        var scrapper = new Scrapper(new XunitLogger<Scrapper>(_testOutputHelper), handler.Object);
+        var scrapper = new DoujinGameScrapper(new XunitLogger<DoujinGameScrapper>(_testOutputHelper));
         var res = await scrapper.ScrapSearchPage("ゴブリンの巣穴");
-
         Assert.NotEmpty(res);
     }
 
+
     [Theory]
-    [InlineData("216826", "https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_216826/")]
-    [InlineData("200809", "https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_200809/?dmmref=ListRanking&i3_ref=list&i3_ord=5")]
-    public void TestGetIdFromGame(string id, string name)
+    [InlineData("https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_216826/")]
+    [InlineData("https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_216826/?dmmref=ListRanking&i3_ref=list&i3_ord=5")]
+    [InlineData("https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_216826/?i3_ref=search&i3_ord=1")]
+    public void ShouldGetIdFromDoujinGameLink(string link)
     {
-        Assert.Equal(id, FanzaMetadataProvider.GetIdFromGame(new Game(name)));
+        var id = DoujinGameScrapper.ParseLinkId(link);
+        Assert.Equal("216826", id);
+    }
+
+
+    [Theory]
+    [InlineData("https://dlsoft.dmm.co.jp/detail/sitri_0011")]
+    [InlineData("https://dlsoft.dmm.co.jp/detail/sitri_0011/?i3_ref=search&i3_ord=1")]
+    public void ShouldGetIdFromLink(string link)
+    {
+        var id = GameScrapper.ParseLinkId(link);
+        Assert.Equal("sitri_0011", id);
+    }
+
+
+    [Fact]
+    public async void ShouldGetSearchResult()
+    {
+        var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapSearchPage("美少女万華鏡 呪われし伝説の少女");
+        Assert.NotEmpty(res);
+    }
+
+    [Fact]
+    public async void ShouldGetScrapperResult()
+    {
+        var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapGamePage(new SearchResult("美少女万華鏡 呪われし伝説の少女", "views_0669",
+            "https://dlsoft.dmm.co.jp/detail/views_0669/"));
+        Assert.NotNull(res);
+        Assert.NotNull(res?.Title);
+        Assert.NotNull(res?.Genres);
+    }
+
+    [Fact]
+    public async void ShouldGetScrapperResult2()
+    {
+        var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var searchRes = await scrapper.ScrapSearchPage("美少女万華鏡 呪われし伝説の少女");
+        Assert.NotEmpty(searchRes);
+
+        var res = await scrapper.ScrapGamePage(searchRes.First());
+        Assert.NotNull(res);
+        Assert.NotNull(res?.Title);
+        Assert.NotNull(res?.Genres);
+    }
+
+
+    [Fact]
+    public async void ShouldNotGetScrapperResult()
+    {
+        var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapGamePage(new SearchResult("djsaklnla", "views_0669111111111",
+            "https://d11111111lsoft.dmm.co.jp/detail/views_0669/"));
+        Assert.Null(res);
+    }
+
+    [Fact]
+    public async void ShouldNotGetScrapperResultNotSupportDomain()
+    {
+        var scrapper = new DoujinGameScrapper(new XunitLogger<DoujinGameScrapper>(_testOutputHelper));
+        var res = await scrapper.ScrapGamePage(new SearchResult("djsaklnla", "views_0669111111111",
+            "https://d11111111lsoft.dmm.co.jp/detail/views_0669/"));
+        Assert.Null(res);
+    }
+
+
+    [Fact]
+    public async void ShouldNotGetScrapperResultSearchAfter()
+    {
+        var s0 = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
+        var manager = new FanzaMetadataProvider.ScrapperManager(new List<IScrapper>() { s0 });
+        var test = await manager.ScrapSearchPage("美少女万華鏡_神が造りたもうた少女たち", CancellationToken.None);
+
+        var var0 = await manager.ScrapGamePage(test.First(), CancellationToken.None);
+        Assert.NotNull(var0);
     }
 }

--- a/src/FanzaMetadata.Test/FanzaTests.cs
+++ b/src/FanzaMetadata.Test/FanzaTests.cs
@@ -70,7 +70,7 @@ public class FanzaTests
     public async void ShouldGetSearchResult()
     {
         var scrapper = new GameScrapper(new XunitLogger<GameScrapper>(_testOutputHelper));
-        var res = await scrapper.ScrapSearchPage("美少女万華鏡 呪われし伝説の少女");
+        var res = await scrapper.ScrapSearchPage("家の彼女");
         Assert.NotEmpty(res);
     }
 

--- a/src/FanzaMetadata/DoujinGameScrapper.cs
+++ b/src/FanzaMetadata/DoujinGameScrapper.cs
@@ -157,6 +157,12 @@ public class DoujinGameScrapper : IScrapper
             }
         }
 
+        var r18NavigationBarLength = document.GetElementsByClassName("_n4v1-link-r18-name").Length;
+        result.Adult = r18NavigationBarLength <= 0;
+
+        var descHtml = document.GetElementsByClassName("summary__txt").First()?.OuterHtml;
+        result.Description = descHtml;
+
         var informationListElements = document.GetElementsByClassName("informationList");
         if (informationListElements.Any())
         {

--- a/src/FanzaMetadata/FanzaMetadataPlugin.cs
+++ b/src/FanzaMetadata/FanzaMetadataPlugin.cs
@@ -34,7 +34,10 @@ public class FanzaMetadataPlugin : MetadataPlugin
         MetadataField.BackgroundImage,
         MetadataField.CommunityScore,
         MetadataField.CoverImage,
-        MetadataField.ReleaseDate
+        MetadataField.ReleaseDate,
+        MetadataField.AgeRating,
+        MetadataField.Description,
+        MetadataField.Region
     };
 
     public FanzaMetadataPlugin(IPlayniteAPI playniteAPI) : base(playniteAPI)

--- a/src/FanzaMetadata/FanzaMetadataProvider.cs
+++ b/src/FanzaMetadata/FanzaMetadataProvider.cs
@@ -255,12 +255,15 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
 
     public override IEnumerable<MetadataProperty> GetAgeRatings(GetMetadataFieldArgs args)
     {
-        var adult = GetResult(args);
-        if (adult is { Adult: true })
+        var res = GetResult(args);
+        var adult = res?.Adult;
+        if (adult == null)
         {
-            return new[] { new MetadataNameProperty("CERO Z") };
+            return base.GetAgeRatings(args);
         }
-        return base.GetAgeRatings(args);
+
+        var ageRating = adult.Value ? "18禁" : "一般向";
+        return new[] { new MetadataNameProperty(ageRating) };
     }
 
     public override IEnumerable<MetadataProperty> GetRegions(GetMetadataFieldArgs args)

--- a/src/FanzaMetadata/FanzaMetadataProvider.cs
+++ b/src/FanzaMetadata/FanzaMetadataProvider.cs
@@ -26,7 +26,7 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
     public override List<MetadataField> AvailableFields => FanzaMetadataPlugin.Fields;
 
     private ScrapperResult? _result;
-    private List<SearchResult>? _searchResults;
+    private string? choosedGameUrl;
     private bool _didRun;
 
     public FanzaMetadataProvider(IPlayniteAPI playniteAPI, Settings settings, MetadataRequestOptions options)
@@ -98,7 +98,7 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
                 return null;
             }
 
-            _searchResults = searchResult;
+            choosedGameUrl = searchResult.First().Href;
         }
         else
         {
@@ -109,7 +109,6 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
                     var searchTask = scrapperManager.ScrapSearchPage(searchString, args.CancelToken);
                     searchTask.Wait(args.CancelToken);
                     var searchResult = searchTask.Result;
-                    _searchResults = searchResult;
                     if (searchResult is null || !searchResult.Any())
                     {
                         _logger.LogError("Search return nothing, make sure you are logged in!");
@@ -129,11 +128,13 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
                 _didRun = true;
                 return null;
             }
+
+            choosedGameUrl = item.Description;
         }
 
-        if (_searchResults != null)
+        if (!string.IsNullOrEmpty(choosedGameUrl))
         {
-            var task = scrapperManager.ScrapGamePage(_searchResults.First(), args.CancelToken);
+            var task = scrapperManager.ScrapGamePage(choosedGameUrl, args.CancelToken);
             task.Wait(args.CancelToken);
             _result = task.Result;
         }

--- a/src/FanzaMetadata/FanzaMetadataProvider.cs
+++ b/src/FanzaMetadata/FanzaMetadataProvider.cs
@@ -64,7 +64,6 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
 
     private ScrapperResult? GetResult(GetMetadataFieldArgs args)
     {
-
         if (_didRun) return _result;
         var scrapperManager = SetupScrapperManager();
 
@@ -103,7 +102,6 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
         }
         else
         {
-
             var item = _playniteAPI.Dialogs.ChooseItemWithSearch(
                 new List<GenericItemOption>(),
                 searchString =>
@@ -246,6 +244,28 @@ public class FanzaMetadataProvider : OnDemandMetadataProvider
             .FirstOrDefault(x => x.Name.Equals(series, StringComparison.OrdinalIgnoreCase));
         if (item is not null) return new[] { new MetadataIdProperty(item.Id) };
         return new[] { new MetadataNameProperty(series) };
+    }
+
+    public override string GetDescription(GetMetadataFieldArgs args)
+    {
+        var result = GetResult(args);
+        if (result is null) return base.GetDescription(args);
+        return result.Description ?? "";
+    }
+
+    public override IEnumerable<MetadataProperty> GetAgeRatings(GetMetadataFieldArgs args)
+    {
+        var adult = GetResult(args);
+        if (adult is { Adult: true })
+        {
+            return new[] { new MetadataNameProperty("CERO Z") };
+        }
+        return base.GetAgeRatings(args);
+    }
+
+    public override IEnumerable<MetadataProperty> GetRegions(GetMetadataFieldArgs args)
+    {
+        return new[] { new MetadataNameProperty("Japan") };
     }
 
     private MetadataFile? SelectImage(GetMetadataFieldArgs args, string caption)

--- a/src/FanzaMetadata/GameScrapper.cs
+++ b/src/FanzaMetadata/GameScrapper.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Common;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Io;
+using Microsoft.Extensions.Logging;
+using Playnite.SDK.Plugins;
+
+namespace FanzaMetadata;
+
+public class GameScrapper : IScrapper
+{
+    private const string BaseSearchUrl = "https://dlsoft.dmm.co.jp/search?service=pcgame&searchstr=";
+    private const string BaseGamePageUrl = "https://dlsoft.dmm.co.jp/detail/";
+    private const string PosterUrlPattern = "https://pics.dmm.co.jp/digital/pcgame/{0}/{0}pl.jpg";
+    private readonly ILogger<GameScrapper> _logger;
+    private readonly IConfiguration _configuration;
+
+    public GameScrapper(ILogger<GameScrapper> logger)
+    {
+        _logger = logger;
+        var clientHandler = new HttpClientHandler();
+        clientHandler.Properties.Add("User-Agent", "Playnite.Extensions");
+        var cookieContainer = new CookieContainer();
+        cookieContainer.Add(new Cookie("age_check_done", "1", "/", ".dmm.co.jp")
+        {
+            Expires = DateTime.Now + TimeSpan.FromDays(30),
+            HttpOnly = true
+        });
+
+        clientHandler.CookieContainer = cookieContainer;
+        _configuration = Configuration.Default.WithRequesters(clientHandler).WithDefaultLoader();
+        clientHandler.UseCookies = true;
+    }
+
+    public GameScrapper(ILogger<GameScrapper> logger, HttpClientHandler messageHandler)
+    {
+        _logger = logger;
+        _configuration = Configuration.Default.WithRequesters(messageHandler).WithDefaultLoader();
+        messageHandler.UseCookies = true;
+    }
+
+
+    public async Task<List<SearchResult>> ScrapSearchPage(string searchName,
+        CancellationToken cancellationToken = default)
+    {
+        var url = BaseSearchUrl + Uri.EscapeUriString(searchName);
+        var context = BrowsingContext.New(_configuration);
+        var document = await context.OpenAsync(url, cancellationToken);
+
+        await Console.Out.WriteAsync(document.Title);
+
+        return document.GetElementsByClassName("component-legacy-productTile")
+            .Where(ele =>
+            {
+                var s = ele.GetElementsByClassName("component-legacy-productTile__detailLink")
+                    .Cast<IHtmlAnchorElement>().First().Href;
+                return !string.IsNullOrEmpty(s);
+            })
+            .Select(element =>
+                {
+                    var title = element.GetElementsByClassName("component-legacy-productTile__title").First().Text();
+                    var href = element.GetElementsByClassName("component-legacy-productTile__detailLink")
+                        .Cast<IHtmlAnchorElement>().First().Href;
+                    var id = new Uri(href).Segments.Last().Replace("/", "");
+                    return new SearchResult(title, id, href);
+                }
+            ).ToList();
+    }
+
+
+    public async Task<ScrapperResult?> ScrapGamePage(SearchResult searchResult,
+        CancellationToken cancellationToken = default)
+    {
+        return await ScrapGamePage(searchResult.Href, cancellationToken);
+    }
+
+    public async Task<ScrapperResult?> ScrapGamePage(string link, CancellationToken cancellationToken)
+    {
+        var id = GetGameIdFromLinks(new List<string> { link });
+
+        _logger.LogInformation("id" + id);
+        if (string.IsNullOrEmpty(id)) return null;
+
+        var context = BrowsingContext.New(_configuration);
+        var document = await context.OpenAsync(link, cancellationToken);
+        if (document.StatusCode == HttpStatusCode.NotFound) return null;
+
+        var result = new ScrapperResult
+        {
+            Link = link
+        };
+        result.Title = document.GetElementById("title")?.Text().Trim();
+        result.Circle = document.GetElementsByClassName("brand").Children(".content").First().Text().Trim();
+
+        result.PreviewImages = document.GetElementsByClassName("image-slider").Children("li").Children("img")
+            .Cast<IHtmlImageElement>().Select(x => x.Source ?? "").Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+        const string ratingPrefix = "d-rating-";
+        result.Rating = document.QuerySelector(".review div")!.ClassList
+            .Where(className => className.StartsWith(ratingPrefix))
+            .Select(className => className.Replace(ratingPrefix, ""))
+            .Select(rating => double.Parse(rating) / 10D).First();
+
+        // <tr>
+        //  <td class="type-left">ダウンロード版対応OS</td>
+        //  <td class="type-center">：</td>
+        //  <td class="type-right"></td>
+        // </tr>
+        // key is type-left class text, value is type-right class element
+        var productDetailDict =
+            document.QuerySelectorAll(".main-area-center .container02 table tbody tr .type-left")
+                .ToDictionary(ele => ele.Text().Trim(),
+                    v => v.ParentElement?.GetElementsByClassName("type-right").First());
+
+        var dateStr = productDetailDict["配信開始日"]?.Text().Trim();
+        if (DateTime.TryParseExact(dateStr, "yyyy/MM/dd", null, DateTimeStyles.None, out var releaseDate))
+        {
+            result.ReleaseDate = releaseDate;
+        }
+
+        const string noneVal = "----";
+        var gameGenre = productDetailDict["ゲームジャンル"]?.Text().Trim();
+        if (!noneVal.Equals(gameGenre))
+        {
+            result.GameGenre = gameGenre;
+        }
+
+        var series = productDetailDict["シリーズ"]?.Text().Trim();
+        if (!noneVal.Equals(series))
+        {
+            result.Series = series;
+        }
+
+        var tags = productDetailDict["ジャンル"]?.GetElementsByTagName("a").Select(x => x.Text().Trim()).ToList();
+        result.Genres = tags;
+
+        result.IconUrl = string.Format(PosterUrlPattern, id);
+        return result;
+    }
+
+    public static string? ParseLinkId(string? link)
+    {
+        if (link == null) return null;
+        return new Uri(link).Segments.Last().Replace("/", "");
+    }
+
+    public string? GetGameIdFromLinks(IEnumerable<string> links)
+    {
+        return links.Where(link =>
+                link.StartsWith(BaseGamePageUrl, StringComparison.OrdinalIgnoreCase))
+            .Select(ParseLinkId).Where(x => !string.IsNullOrEmpty(x)).FirstOrDefault();
+    }
+}

--- a/src/FanzaMetadata/GameScrapper.cs
+++ b/src/FanzaMetadata/GameScrapper.cs
@@ -86,8 +86,6 @@ public class GameScrapper : IScrapper
     public async Task<ScrapperResult?> ScrapGamePage(string link, CancellationToken cancellationToken)
     {
         var id = GetGameIdFromLinks(new List<string> { link });
-
-        _logger.LogInformation("id" + id);
         if (string.IsNullOrEmpty(id)) return null;
 
         var context = BrowsingContext.New(_configuration);
@@ -109,6 +107,11 @@ public class GameScrapper : IScrapper
             .Where(className => className.StartsWith(ratingPrefix))
             .Select(className => className.Replace(ratingPrefix, ""))
             .Select(rating => double.Parse(rating) / 10D).First();
+
+        result.Description = document.QuerySelector(".read-text-area p.text-overflow")?.OuterHtml.Trim();
+
+        var r18NavigationBarLength = document.GetElementsByClassName("_n4v1-link-r18-name").Length;
+        result.Adult = r18NavigationBarLength <= 0;
 
         // <tr>
         //  <td class="type-left">ダウンロード版対応OS</td>

--- a/src/FanzaMetadata/GameScrapper.cs
+++ b/src/FanzaMetadata/GameScrapper.cs
@@ -52,24 +52,19 @@ public class GameScrapper : IScrapper
     public async Task<List<SearchResult>> ScrapSearchPage(string searchName,
         CancellationToken cancellationToken = default)
     {
-        var url = BaseSearchUrl + Uri.EscapeUriString(searchName);
+        var url = BaseSearchUrl + searchName;
         var context = BrowsingContext.New(_configuration);
         var document = await context.OpenAsync(url, cancellationToken);
 
         await Console.Out.WriteAsync(document.Title);
 
-        return document.GetElementsByClassName("component-legacy-productTile")
-            .Where(ele =>
-            {
-                var s = ele.GetElementsByClassName("component-legacy-productTile__detailLink")
-                    .Cast<IHtmlAnchorElement>().First().Href;
-                return !string.IsNullOrEmpty(s);
-            })
+
+        return document.QuerySelectorAll(".component-legacy-productTile .component-legacy-productTile__detailLink")
+            .Where(element => !string.IsNullOrEmpty(element.HyperReference("")?.Href))
             .Select(element =>
                 {
                     var title = element.GetElementsByClassName("component-legacy-productTile__title").First().Text();
-                    var href = element.GetElementsByClassName("component-legacy-productTile__detailLink")
-                        .Cast<IHtmlAnchorElement>().First().Href;
+                    var href = element.HyperReference("").Href;
                     var id = new Uri(href).Segments.Last().Replace("/", "");
                     return new SearchResult(title, id, href);
                 }

--- a/src/FanzaMetadata/GameScrapper.cs
+++ b/src/FanzaMetadata/GameScrapper.cs
@@ -52,7 +52,7 @@ public class GameScrapper : IScrapper
     public async Task<List<SearchResult>> ScrapSearchPage(string searchName,
         CancellationToken cancellationToken = default)
     {
-        var url = BaseSearchUrl + searchName;
+        var url = BaseSearchUrl + Uri.EscapeUriString(searchName);
         var context = BrowsingContext.New(_configuration);
         var document = await context.OpenAsync(url, cancellationToken);
 
@@ -64,7 +64,8 @@ public class GameScrapper : IScrapper
             .Select(element =>
                 {
                     var title = element.GetElementsByClassName("component-legacy-productTile__title").First().Text();
-                    var href = element.HyperReference("").Href;
+                    var anchorElement = (IHtmlAnchorElement)element;
+                    var href = anchorElement.Href;
                     var id = new Uri(href).Segments.Last().Replace("/", "");
                     return new SearchResult(title, id, href);
                 }

--- a/src/FanzaMetadata/IScrapper.cs
+++ b/src/FanzaMetadata/IScrapper.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Playnite.SDK.Plugins;
+
+namespace FanzaMetadata;
+
+public interface IScrapper
+{
+    Task<List<SearchResult>> ScrapSearchPage(string searchName, CancellationToken cancellationToken);
+
+    Task<ScrapperResult?> ScrapGamePage(SearchResult result, CancellationToken cancellationToken);
+
+    Task<ScrapperResult?> ScrapGamePage(string link, CancellationToken cancellationToken);
+
+    string? GetGameIdFromLinks(IEnumerable<string> links);
+}

--- a/src/FanzaMetadata/ScrapperResult.cs
+++ b/src/FanzaMetadata/ScrapperResult.cs
@@ -25,6 +25,10 @@ public class ScrapperResult
     public List<string>? Genres { get; set; }
 
     public string? IconUrl { get; set; }
+
+    public string? Description { get; set; }
+
+    public bool Adult { get; set; }
 }
 
 [DebuggerDisplay("{Name} ({Id})")]

--- a/src/FanzaMetadata/ScrapperResult.cs
+++ b/src/FanzaMetadata/ScrapperResult.cs
@@ -28,7 +28,7 @@ public class ScrapperResult
 
     public string? Description { get; set; }
 
-    public bool Adult { get; set; }
+    public bool? Adult { get; set; }
 }
 
 [DebuggerDisplay("{Name} ({Id})")]

--- a/src/FanzaMetadata/ScrapperResult.cs
+++ b/src/FanzaMetadata/ScrapperResult.cs
@@ -32,10 +32,12 @@ public class SearchResult
 {
     public readonly string Name;
     public readonly string Id;
+    public readonly string Href;
 
-    public SearchResult(string name, string id)
+    public SearchResult(string name, string id, string href)
     {
         Name = name;
         Id = id;
+        Href = href;
     }
 }

--- a/src/FanzaMetadata/Settings.cs
+++ b/src/FanzaMetadata/Settings.cs
@@ -12,8 +12,8 @@ public class Settings : ISettings
     private IPlayniteAPI? _playniteAPI;
     private Plugin? _plugin;
 
-    public PlayniteProperty GenreProperty { get; set; } = PlayniteProperty.Genres;
-    public PlayniteProperty GameGenreProperty { get; set; } = PlayniteProperty.Features;
+    public PlayniteProperty GenreProperty { get; set; } = PlayniteProperty.Tags;
+    public PlayniteProperty GameGenreProperty { get; set; } = PlayniteProperty.Genres;
 
     public Settings() { }
 
@@ -25,6 +25,8 @@ public class Settings : ISettings
         var savedSettings = plugin.LoadPluginSettings<Settings>();
         if (savedSettings is not null)
         {
+            GenreProperty = savedSettings.GenreProperty;
+            GameGenreProperty = savedSettings.GameGenreProperty;
         }
     }
 


### PR DESCRIPTION
The current version only supports doujin games, the pr version now crawls enterprise games first and then crawls doujin games if not. Also add some meatadata properties for Fanza and DLsite.